### PR TITLE
Fixed pom.xml descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,7 @@
 
   <groupId>gelf4j</groupId>
   <artifactId>gelf4j</artifactId>
-  <version>0.10-SNAPSHOT</version>
-  <packaging>bundle</packaging>
+  <version>1.6-SNAPSHOT</version>
 
   <name>GELF4j</name>
   <description>GELF4j: Library for sending log messages using the GELF protocol</description>
@@ -86,22 +85,18 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>1.1</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <version>1.2.8</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>0.9.29</version>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <version>0.9.29</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>spice</groupId>


### PR DESCRIPTION
- json-simple is not optional
- logging frameworks are optional dependencies
- log4j downgraded to 1.2.8 to match buildr
- removed logback-core, since it's included as transient dependency from logback-classic
- version updated to 1.6-SNAPSHOT
